### PR TITLE
Dangerのworkflowにpull-requestsのwrite権限を追加

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,6 +2,9 @@ name: danger
 
 on: pull_request
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 解決したいこと
- いくつかのCIが403で失敗する

## やったこと
- Dangerのworkflowにpull-requestsのwrite権限を追加

## やらないこと
- 

## 動作確認環境
- 
