### PR TITLE
kotlinを1.7.20に更新

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    kotlinVersion = '1.7.10'
+    kotlinVersion = '1.7.20'
     androidXCoreVersion = '1.7.0'
     activityVersion = '1.5.1'
     composeVersion = '1.1.1'


### PR DESCRIPTION
## 解決したいこと
- Compose compilerを1.3.2に更新する際にKotlinのバージョンも更新しないとビルドできなかったので対応

## やったこと
- Kotlinのバージョンを1.7.10から1.7.20に更新

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
