### PR TITLE
Jetpack Compose ライブラリバージョンを BOM 2023.01.00 に更新

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 ext.versions = [
-        compileSdk: 32,
+        compileSdk: 33,
         targetSdk : 30,
         minSdk    : 23,
 ]

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 
     implementation deps.androidX.appCompat
     implementation deps.androidX.activity.compose
+    implementation platform(deps.androidX.compose.bom)
     implementation deps.androidX.compose.ui
     implementation deps.androidX.compose.uiTooling
     implementation deps.androidX.compose.material

--- a/catalog/src/main/java/net/pixiv/charcoal/android/catalog/compose/CharcoalRadioButtonComposeActivity.kt
+++ b/catalog/src/main/java/net/pixiv/charcoal/android/catalog/compose/CharcoalRadioButtonComposeActivity.kt
@@ -5,13 +5,12 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -71,23 +70,30 @@ private fun RadioButtonCatalog(
                     }
                 )
             }
-        ) {
+        ) { innerPadding ->
             val states = mutableListOf(
                 RadioButtonState(enabled = true, selected = false),
                 RadioButtonState(enabled = true, selected = true),
                 RadioButtonState(enabled = false, selected = false),
                 RadioButtonState(enabled = false, selected = true),
             )
-            RadioButtonGrid(radioButtonStates = states)
+
+            RadioButtonGrid(
+                modifier = Modifier.padding(innerPadding),
+                radioButtonStates = states
+            )
         }
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun RadioButtonGrid(radioButtonStates: List<RadioButtonState>) {
+private fun RadioButtonGrid(
+    modifier: Modifier = Modifier,
+    radioButtonStates: List<RadioButtonState>
+) {
     LazyVerticalGrid(
-        cells = GridCells.Fixed(2)
+        modifier = modifier,
+        columns = GridCells.Fixed(2),
     ) {
         items(radioButtonStates) {
             CharcoalRadioButtonSample(radioButtonState = it)
@@ -100,12 +106,14 @@ private fun CharcoalRadioButtonSample(radioButtonState: RadioButtonState) {
     var selectedState by remember { mutableStateOf(radioButtonState.selected) }
 
     Row(
-        modifier = Modifier.toggleable(
-            value = selectedState,
-            role = Role.RadioButton,
-            enabled = radioButtonState.enabled,
-            onValueChange = { selectedState = !selectedState }
-        ).padding(8.dp),
+        modifier = Modifier
+            .toggleable(
+                value = selectedState,
+                role = Role.RadioButton,
+                enabled = radioButtonState.enabled,
+                onValueChange = { selectedState = !selectedState }
+            )
+            .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         CharcoalRadioButton(

--- a/catalog/src/main/java/net/pixiv/charcoal/android/catalog/compose/CharcoalTopAppBarComposeActivity.kt
+++ b/catalog/src/main/java/net/pixiv/charcoal/android/catalog/compose/CharcoalTopAppBarComposeActivity.kt
@@ -67,7 +67,7 @@ private fun TopAppBarCatalog(
                 )
             },
             backgroundColor = CharcoalTheme.colorToken.background2
-        ) {
+        ) { innerPadding ->
             val states = mutableListOf(
                 TopAppBarSampleSetting(
                     titleText = "Default",
@@ -79,14 +79,20 @@ private fun TopAppBarCatalog(
                     background = CharcoalTheme.colorToken.surface3
                 ),
             )
-            TopAppBarList(topAppBarSettings = states)
+            TopAppBarList(
+                modifier = Modifier.padding(innerPadding),
+                topAppBarSettings = states
+            )
         }
     }
 }
 
 @Composable
-private fun TopAppBarList(topAppBarSettings: List<TopAppBarSampleSetting>) {
-    LazyColumn {
+private fun TopAppBarList(
+    modifier: Modifier = Modifier,
+    topAppBarSettings: List<TopAppBarSampleSetting>
+) {
+    LazyColumn(modifier = modifier) {
         items(topAppBarSettings) {
             CharcoalTopAppBarSample(topAppBarSetting = it)
         }

--- a/charcoal-android-compose/build.gradle
+++ b/charcoal-android-compose/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
     implementation deps.androidX.activity.compose
     implementation deps.androidX.compose.compiler
+    implementation platform(deps.androidX.compose.bom)
     implementation deps.androidX.compose.ui
     implementation deps.androidX.compose.uiTooling
     implementation deps.androidX.compose.material

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,6 @@ ext {
     kotlinVersion = '1.7.20'
     androidXCoreVersion = '1.7.0'
     activityVersion = '1.5.1'
-    composeVersion = '1.1.1'
     composeCompilerVersion = '1.3.2'
     groupieVersion = "2.9.0"
     dokkaVersion = '1.7.20'
@@ -23,9 +22,10 @@ ext.deps = [
                 ],
                 compose         : [
                         compiler : "androidx.compose.compiler:compiler:$composeCompilerVersion",
-                        ui       : "androidx.compose.ui:ui:$composeVersion",
-                        uiTooling: "androidx.compose.ui:ui-tooling:$composeVersion",
-                        material : "androidx.compose.material:material:$composeVersion"
+                        bom      : "androidx.compose:compose-bom:2023.01.00",
+                        ui       : "androidx.compose.ui:ui",
+                        uiTooling: "androidx.compose.ui:ui-tooling",
+                        material : "androidx.compose.material:material"
                 ],
                 fragment        : 'androidx.fragment:fragment-ktx:1.4.1',
                 material        : 'com.google.android.material:material:1.6.1',


### PR DESCRIPTION
## 解決したいこと
- Jetpack Compose のライブラリバージョンが古い状態であるため、新しいものを利用した状態にしたい。

## やったこと
- compileSdk の設定を 33 に変更
  - Jetpack Compose ライブラリ最新化のため必要であったため対応。
- Jetpack Compose のバージョン管理に BOM を導入し BOM 2023.01.00 を利用する
  - バージョン更新により、動かなくなってしまった箇所も一緒に修正しています。

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
<img src="https://user-images.githubusercontent.com/117521358/218051001-429cc674-bbe3-486c-bcab-7f276f7ad248.png" width="300">|<img src="https://user-images.githubusercontent.com/117521358/218051032-ca5bc283-1086-431f-8d70-9c888bb26921.png" width="300">
<img src="https://user-images.githubusercontent.com/117521358/218051060-dff25a1d-2c1f-448c-8126-ec482b36706d.png" width="300">|<img src="https://user-images.githubusercontent.com/117521358/218051103-5347ade6-c34f-42af-8740-97378de82415.png" width="300">
<img src="https://user-images.githubusercontent.com/117521358/218051259-fe468e4c-7592-41ed-9c76-d8ce1ce8a5e1.png" width="300">|<img src="https://user-images.githubusercontent.com/117521358/218051279-3de92c3f-3242-4945-aa45-54025cd87ddb.png" width="300">


## 動作確認環境
- 
