### PR TITLE
ForkしたPRでDangerが動かないのを修正

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: set up JDK 11
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
## 解決したいこと
- Dangerが動かない

## やったこと
- https://github.com/danger/danger/issues/1103#issuecomment-635539947 に倣って `fetch-depth` を0にする

