### PR TITLE
CharcoalDialogFragment に Fragment Result Listener の requestKey を指定可能にする

### DIFF
--- a/catalog/src/main/java/net/pixiv/charcoal/android/catalog/dialog/DialogActivity.kt
+++ b/catalog/src/main/java/net/pixiv/charcoal/android/catalog/dialog/DialogActivity.kt
@@ -47,7 +47,10 @@ class DialogActivity : AppCompatActivity(R.layout.activity_dialog) {
             SampleBottomSheetDialogFragment().showNow(supportFragmentManager, DIALOG_TAG)
         }
 
-        supportFragmentManager.setFragmentResultListener(CharcoalDialogFragment.FRAGMENT_REQUEST_KEY, this) { _, result ->
+        supportFragmentManager.setFragmentResultListener(
+            CharcoalDialogFragment.FRAGMENT_REQUEST_KEY,
+            this
+        ) { _, result ->
             when (result.getParcelable<DialogActivityEvent>(CharcoalDialogFragment.FRAGMENT_RESULT_KEY_CHARCOAL_DIALOG_EVENT)) {
                 DialogActivityEvent.SelectPrimaryButton -> {
                     Toast.makeText(this, "select primary button", Toast.LENGTH_SHORT).show()

--- a/charcoal-android/src/main/java/net/pixiv/charcoal/android/view/dialog/CharcoalDialogFragment.kt
+++ b/charcoal-android/src/main/java/net/pixiv/charcoal/android/view/dialog/CharcoalDialogFragment.kt
@@ -117,15 +117,17 @@ class CharcoalDialogFragment : DialogFragment() {
     }
 
     private fun setFragmentResult(dialogEvent: CharcoalDialogEvent) {
+        val requestKey = checkNotNull(requireArguments().getString(ARGUMENTS_REQUEST_KEY))
+
         parentFragmentManager.setFragmentResult(
-            FRAGMENT_REQUEST_KEY,
+            requestKey,
             bundleOf(FRAGMENT_RESULT_KEY_CHARCOAL_DIALOG_EVENT to dialogEvent)
         )
     }
 
     companion object {
         /**
-         * setFragmentResultListener の requestKey に設定する値
+         * setFragmentResultListener の requestKey に設定するデフォルト値
          */
         const val FRAGMENT_REQUEST_KEY = "fragment_request_key_charcoal_dialog_fragment"
 
@@ -148,12 +150,18 @@ class CharcoalDialogFragment : DialogFragment() {
             "arguments_cancel_button_colored_background"
 
         /**
+         * FragmentResultListener に設定する requestKey を保持するための Bundle key
+         */
+        private const val ARGUMENTS_REQUEST_KEY = "arguments_request_key"
+
+        /**
          * CharcoalDialogFragment に arguments を設定したインスタンスを取得する。
          *
          * @param title ポップアップのタイトル
          * @param message ポップアップのメッセージ
          * @param buttonSettings [CharcoalDialogButtonSettings] を利用したボタン表示設定
          * @param isCancelable ダイアログをキャンセルできるか。キャンセルできる場合は閉じるボタンを表示する。
+         * @param requestKey Fragment Result Listener で利用する requestKey
          * @return arguments が設定された CharcoalDialogFragment のインスタンス
          */
         fun newInstance(
@@ -163,6 +171,7 @@ class CharcoalDialogFragment : DialogFragment() {
             buttonSettings: CharcoalDialogButtonSettings,
             isCancelable: Boolean = true,
             cancelButtonColoredBackground: Boolean = false,
+            requestKey: String = FRAGMENT_REQUEST_KEY
         ): CharcoalDialogFragment {
             return CharcoalDialogFragment().also { fragment ->
                 fragment.arguments = Bundle().also { bundle ->
@@ -177,6 +186,7 @@ class CharcoalDialogFragment : DialogFragment() {
                         ARGUMENTS_CANCEL_BUTTON_COLORED_BACKGROUND,
                         cancelButtonColoredBackground
                     )
+                    bundle.putString(ARGUMENTS_REQUEST_KEY, requestKey)
                 }
             }
         }


### PR DESCRIPTION
## 解決したいこと
- 現状、CharcoalDialogFragment からFragment Result Listener で値を受け取るための requestKey が固定となっており、Fragment Result Listener を2つ以上設定する場合に片方を上書きしてしまう。上書きされないように対処したい。

## やったこと
- requestKey を CharcoalDialogFragment#newInstance で指定できるよう変更しました。

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- [x] カタログアプリのダイアログ画面にて、 `CharcoalDialog 表示2` で表示されるダイアログの OK ボタンを押したときに Toast が表示されること。
