### PR TITLE
GitHub Actions でカタログアプリをビルドする step を追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-        cache: gradle
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: gradle
 
-    - name: Run ktlintCheck
-      run: ./gradlew ktlintCheck
+      - name: Run ktlintCheck
+        run: ./gradlew ktlintCheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: danger
+name: build
 
 on: pull_request
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,8 @@ jobs:
           distribution: 'adopt'
           cache: gradle
 
+      - name: Build catalog app
+        run: ./gradlew :catalog:assembleDebug
+
       - name: Run ktlintCheck
         run: ./gradlew ktlintCheck


### PR DESCRIPTION
## 解決したいこと
- 現状、 GitHub Actions ではコードの静的解析のみ実行されており、各ライブラリモジュールのビルドが実行されていない。charcoal-android が依存しているライブラリのアップデートなどでビルドが壊れても GitHub Actions で気づくことができないため、 各ライブラリモジュールをビルドするようにしたい。

## やったこと
- Workflow のファイルを build.yml という汎用的な名称に変更しました。( Now in Android, DroidKaigi Conference App 2022  参考
- build.yml でコードフォーマットを実行しました。
- GitHub Actions の workflow `danger` に、catalog アプリモジュールをビルドする step を追加しました。

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
