### PR TITLE
Revert "Bump kotlinVersion from 1.7.20 to 1.8.0"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    kotlinVersion = '1.8.0'
+    kotlinVersion = '1.7.20'
     androidXCoreVersion = '1.9.0'
     activityVersion = '1.6.1'
     composeVersion = '1.3.1'


### PR DESCRIPTION
Reverts pixiv/charcoal-android#32

https://developer.android.com/jetpack/androidx/releases/compose-kotlin?hl=ja#pre-release_kotlin_compatibility

kotlin 1.8.0に対してはCompose Compiler 1.4.0が必要であり、ビルドできなくなっている。
一旦リバートを行い、まとめてバージョンアップを行う。