### PR TITLE
Revert "Bump core-ktx from 1.7.0 to 1.9.0"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     kotlinVersion = '1.7.20'
-    androidXCoreVersion = '1.9.0'
+    androidXCoreVersion = '1.7.0'
     activityVersion = '1.5.1'
     composeVersion = '1.1.1'
     composeCompilerVersion = '1.3.2'


### PR DESCRIPTION
Reverts pixiv/charcoal-android#7

compileSdkVersion 33が必要なため、一度リバートする

```
 1.  Dependency 'androidx.core:core:1.9.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :catalog is currently compiled against android-32.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 33, for example 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
```