### PR TITLE
Maven Centralへのアップロード処理

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:7.3.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+        classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -51,5 +52,9 @@ subprojects {
     }
 }
 
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+apply from: "${rootDir}/scripts/publish/publish-root.gradle"
+
 task clean(type: Delete) {
-    delete rootProject.buildDir}
+    delete rootProject.buildDir
+}

--- a/charcoal-android-compose/build.gradle
+++ b/charcoal-android-compose/build.gradle
@@ -1,11 +1,12 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'signing'
     id 'maven-publish'
     id 'org.jetbrains.dokka'
 }
 
-group = "net.pixiv.charcoal-android"
+group = "net.pixiv.charcoal"
 version = findProperty('CHARCOAL_RELEASE_VERSION') ?: System.getenv('CHARCOAL_RELEASE_VERSION') ?: ""
 
 android {
@@ -63,20 +64,6 @@ dependencies {
     androidTestImplementation deps.androidX.test.espresso
 }
 
-def getRepositoryUrl() {
-    def releasesRepoUrl = findProperty('NEXUS_MAVEN_RELEASE_REPOSITORY') ?: System.getenv('NEXUS_MAVEN_RELEASE_REPOSITORY') ?: ""
-    def snapshotsRepoUrl = findProperty('NEXUS_MAVEN_SNAPSHOT_REPOSITORY') ?: System.getenv('NEXUS_MAVEN_SNAPSHOT_REPOSITORY') ?: ""
-    return uri(version.toString().endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl)
-}
-
-def getRepositoryUsername() {
-    return findProperty('NEXUS_MAVEN_USERNAME') ?: System.getenv('NEXUS_MAVEN_USERNAME') ?: ""
-}
-
-def getRepositoryPassword() {
-    return findProperty('NEXUS_MAVEN_PASSWORD') ?: System.getenv('NEXUS_MAVEN_PASSWORD') ?: ""
-}
-
 afterEvaluate {
     publishing {
         publications {
@@ -84,22 +71,43 @@ afterEvaluate {
                 from components.release
                 artifact androidSourcesJar
 
-                groupId = "net.pixiv.charcoal-android"
-                artifactId = "charcoal-android-compose"
-                version = version
-            }
-        }
-        repositories {
-            maven {
-                url = getRepositoryUrl()
+                groupId group
+                artifactId "charcoal-compose"
+                version version
 
-                credentials {
-                    username = getRepositoryUsername()
-                    password = getRepositoryPassword()
+                pom {
+                    name = "charcoal-android-compose"
+                    description = "Design system library by pixiv"
+                    url = "https://github.com/pixiv/charcoal-android"
+
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'kwzr'
+                            name = 'Kazumasa Kawazure'
+                            email = "kwzr@pixiv.co.jp"
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:github.com/pixiv/charcoal-android.git'
+                        developerConnection = 'scm:git:ssh://github.com/pixiv/charcoal-android.git'
+                        url = 'https://github.com/pixiv/charcoal-android/tree/main'
+                    }
                 }
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications
 }
 
 task androidSourcesJar(type: Jar) {

--- a/charcoal-android/build.gradle
+++ b/charcoal-android/build.gradle
@@ -1,11 +1,12 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'signing'
     id 'maven-publish'
     id 'org.jetbrains.dokka'
 }
 
-group = "net.pixiv.charcoal-android"
+group = "net.pixiv.charcoal"
 version = findProperty('CHARCOAL_RELEASE_VERSION') ?: System.getenv('CHARCOAL_RELEASE_VERSION') ?: ""
 
 android {
@@ -46,20 +47,6 @@ dependencies {
     androidTestImplementation deps.androidX.test.espresso
 }
 
-def getRepositoryUrl() {
-    def releasesRepoUrl = findProperty('NEXUS_MAVEN_RELEASE_REPOSITORY') ?: System.getenv('NEXUS_MAVEN_RELEASE_REPOSITORY') ?: ""
-    def snapshotsRepoUrl = findProperty('NEXUS_MAVEN_SNAPSHOT_REPOSITORY') ?: System.getenv('NEXUS_MAVEN_SNAPSHOT_REPOSITORY') ?: ""
-    return uri(version.toString().endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl)
-}
-
-def getRepositoryUsername() {
-    return findProperty('NEXUS_MAVEN_USERNAME') ?: System.getenv('NEXUS_MAVEN_USERNAME') ?: ""
-}
-
-def getRepositoryPassword() {
-    return findProperty('NEXUS_MAVEN_PASSWORD') ?: System.getenv('NEXUS_MAVEN_PASSWORD') ?: ""
-}
-
 afterEvaluate {
     publishing {
         publications {
@@ -67,22 +54,43 @@ afterEvaluate {
                 from components.release
                 artifact androidSourcesJar
 
-                groupId = "net.pixiv.charcoal-android"
-                artifactId = "charcoal-android"
-                version = version
-            }
-        }
-        repositories {
-            maven {
-                url = getRepositoryUrl()
+                groupId group
+                artifactId "charcoal-android-view"
+                version version
 
-                credentials {
-                    username = getRepositoryUsername()
-                    password = getRepositoryPassword()
+                pom {
+                    name = "charcoal-android"
+                    description = "Design system library by pixiv"
+                    url = "https://github.com/pixiv/charcoal-android"
+
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'kwzr'
+                            name = 'Kazumasa Kawazure'
+                            email = "kwzr@pixiv.co.jp"
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:github.com/pixiv/charcoal-android.git'
+                        developerConnection = 'scm:git:ssh://github.com/pixiv/charcoal-android.git'
+                        url = 'https://github.com/pixiv/charcoal-android/tree/main'
+                    }
                 }
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications
 }
 
 task androidSourcesJar(type: Jar) {

--- a/scripts/publish/publish-root.gradle
+++ b/scripts/publish/publish-root.gradle
@@ -1,0 +1,34 @@
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["signing.password"] = ''
+ext["signing.keyId"] = ''
+
+// local.propertiesがある場合はその値を、なければ環境変数を使う
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    ext["ossrhUsername"] = System.getenv('SONATYPE_USERNAME')
+    ext["ossrhPassword"] = System.getenv('SONATYPE_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.secretKeyRingFile"] = System.getenv('MAVEN_CENTRAL_SIGNING_KEY_RING_FILE')
+    ext["signing.password"] = System.getenv('MAVEN_CENTRAL_SIGNING_PASSWORD')
+    ext["signing.keyId"] = System.getenv('MAVEN_CENTRAL_SIGNING_KEY_ID')
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}


### PR DESCRIPTION
## 解決したいこと
- Maven Centralへのアップロード処理をCIに乗せる

## やったこと
- mavenの向き先をCentralへ変更
- 署名のロジックを追加
- 各種定数はCIのsecretで定義。ローカルで手動実行する場合は`local.properties`に記述する

## やらないこと
- 

## 動作確認環境
- 

## できればやりたいこと
`afterEvaluate`の中身がViewもComposeもだいたい同じなので共通化したい…
