### PR TITLE
CharcoalTabLayoutの追加（AndroidView版）

### DIFF
--- a/catalog/src/main/java/net/pixiv/charcoal/android/catalog/tabLayout/TabLayoutActivity.kt
+++ b/catalog/src/main/java/net/pixiv/charcoal/android/catalog/tabLayout/TabLayoutActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.tabs.TabLayout
 import com.wada811.viewbinding.viewBinding
 import net.pixiv.charcoal.android.catalog.R
 import net.pixiv.charcoal.android.catalog.databinding.ActivityTabLayoutBinding
@@ -22,24 +21,12 @@ class TabLayoutActivity : AppCompatActivity(R.layout.activity_tab_layout) {
             toolbar = binding.toolBar,
             title = "TabLayout"
         )
-
-        binding.tabLayoutS.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-
-            override fun onTabSelected(tab: TabLayout.Tab?) {
-            }
-
-            override fun onTabReselected(tab: TabLayout.Tab?) {
-            }
-
-            override fun onTabUnselected(tab: TabLayout.Tab?) {
-            }
-        })
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
                 return true
             }
         }

--- a/catalog/src/main/res/layout/activity_tab_layout.xml
+++ b/catalog/src/main/res/layout/activity_tab_layout.xml
@@ -7,15 +7,6 @@
     android:background="?attr/colorCharcoalBackground2"
     tools:context=".tabLayout.TabLayoutActivity">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/tool_bar"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/container"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/container"
         android:layout_width="0dp"
@@ -26,30 +17,98 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tool_bar">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text='app:tabMode="fixed"' />
+
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="16dp">
 
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tab_layout_s"
+            <net.pixiv.charcoal.android.view.constant.CharcoalTabLayout
+                android:id="@+id/tab_layout_fixed"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                app:tabMode="fixed">
 
                 <com.google.android.material.tabs.TabItem
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Item1"
-                    />
+                    android:text="Item1" />
 
                 <com.google.android.material.tabs.TabItem
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Item2"
-                    />
+                    android:text="Item2" />
 
-            </com.google.android.material.tabs.TabLayout>
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item3" />
+
+            </net.pixiv.charcoal.android.view.constant.CharcoalTabLayout>
+        </FrameLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text='app:tabMode="scrollable"' />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp">
+
+            <net.pixiv.charcoal.android.view.constant.CharcoalTabLayout
+                android:id="@+id/tab_layout_scrollable"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:tabMode="scrollable">
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item1" />
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item2" />
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item3" />
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item4" />
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item5" />
+
+                <com.google.android.material.tabs.TabItem
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Item6" />
+
+            </net.pixiv.charcoal.android.view.constant.CharcoalTabLayout>
         </FrameLayout>
     </androidx.appcompat.widget.LinearLayoutCompat>
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/tool_bar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/container"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/catalog/src/main/res/layout/activity_tab_layout.xml
+++ b/catalog/src/main/res/layout/activity_tab_layout.xml
@@ -18,8 +18,11 @@
         app:layout_constraintTop_toBottomOf="@id/tool_bar">
 
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:textAppearance="@style/TextAppearance.Charcoal.Bold.16"
+            android:textColor="?attr/colorCharcoalText1"
             android:text='app:tabMode="fixed"' />
 
         <FrameLayout
@@ -52,9 +55,11 @@
         </FrameLayout>
 
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
+            android:padding="16dp"
+            android:textAppearance="@style/TextAppearance.Charcoal.Bold.16"
+            android:textColor="?attr/colorCharcoalText1"
             android:text='app:tabMode="scrollable"' />
 
         <FrameLayout

--- a/catalog/src/main/res/layout/view_tab_text.xml
+++ b/catalog/src/main/res/layout/view_tab_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    style="@style/TextAppearance.Design.Tab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="16dp" />

--- a/charcoal-android/src/main/java/net/pixiv/charcoal/android/view/constant/CharcoalTabLayout.kt
+++ b/charcoal-android/src/main/java/net/pixiv/charcoal/android/view/constant/CharcoalTabLayout.kt
@@ -1,0 +1,16 @@
+package net.pixiv.charcoal.android.view.constant
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.tabs.TabLayout
+import net.pixiv.charcoal.android.R
+
+class CharcoalTabLayout @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null
+) : TabLayout(context, attrs) {
+
+    override fun addTab(tab: Tab, position: Int, setSelected: Boolean) {
+        val charcoalTab = tab.setCustomView(R.layout.view_charcoal_tab)
+        super.addTab(charcoalTab, position, setSelected)
+    }
+}

--- a/charcoal-android/src/main/res/layout/view_charcoal_tab.xml
+++ b/charcoal-android/src/main/res/layout/view_charcoal_tab.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    style="@style/TextAppearance.Design.Tab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="16dp" />

--- a/charcoal-android/src/main/res/layout/view_charcoal_tab.xml
+++ b/charcoal-android/src/main/res/layout/view_charcoal_tab.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@android:id/text1"
-    style="@style/TextAppearance.Design.Tab"
+    style="@style/TextAppearance.Charcoal.Design.Tab"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:paddingHorizontal="16dp" />

--- a/charcoal-android/src/main/res/values/styles.xml
+++ b/charcoal-android/src/main/res/values/styles.xml
@@ -89,6 +89,7 @@
         <item name="android:layout_gravity">bottom|center_horizontal</item>
         <item name="android:background">?attr/colorCharcoalSurface1</item>
         <item name="tabIndicatorColor">?attr/colorCharcoalBrand</item>
+        <item name="tabIndicatorFullWidth">false</item>
         <item name="tabIndicatorHeight">2dp</item>
         <item name="tabSelectedTextColor">?attr/colorCharcoalText1</item>
         <item name="tabTextAppearance">@style/TextAppearance.Charcoal.Regular.14</item>

--- a/charcoal-android/src/main/res/values/styles.xml
+++ b/charcoal-android/src/main/res/values/styles.xml
@@ -92,9 +92,13 @@
         <item name="tabIndicatorFullWidth">false</item>
         <item name="tabIndicatorHeight">2dp</item>
         <item name="tabSelectedTextColor">?attr/colorCharcoalText1</item>
-        <item name="tabTextAppearance">@style/TextAppearance.Charcoal.Regular.14</item>
+        <item name="tabTextAppearance">@style/TextAppearance.Charcoal.Design.Tab</item>
         <item name="tabTextColor">?attr/colorCharcoalText3</item>
         <item name="tabRippleColor">?attr/colorCharcoalSurface10</item>
+    </style>
+
+    <style name="TextAppearance.Charcoal.Design.Tab" parent="TextAppearance.Design.Tab">
+        <item name="textAllCaps">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## 解決したいこと
- `TabLayout`にCharcoalの定義を追加する

## やったこと
- `CharcoalTabLayout`の追加
- 内部Textにpaddingを設定
- カタログにTabLayoutの追加

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---
![Screenshot_20230706_182512](https://github.com/pixiv/charcoal-android/assets/1505139/3acbe585-b000-4b94-959a-2178e07da17c)|![Screenshot_20230706_181928](https://github.com/pixiv/charcoal-android/assets/1505139/43a923d2-7c82-4f04-945f-ac2e7a0406e6)

## 動作確認環境
- 
