### PR TITLE
Central Publisher Portal への移行のため publish-plugin の設定を更新

### DIFF
--- a/scripts/publish/publish-root.gradle
+++ b/scripts/publish/publish-root.gradle
@@ -27,8 +27,8 @@ nexusPublishing {
             username = ossrhUsername
             password = ossrhPassword
 
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
## 解決したいこと
- OSSRH 終了につき Central Publisher Portal へ移行する必要がある。
  - https://central.sonatype.org/pages/ossrh-eol/

## やったこと
- [publish-plugin](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#2-make-separate-requests) の設定を、公式ドキュメントを元に更新。

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
