### PR TITLE
Maven Central Repository 移行のための設定変更

### DIFF
--- a/scripts/publish/publish-root.gradle
+++ b/scripts/publish/publish-root.gradle
@@ -20,10 +20,11 @@ if (secretPropsFile.exists()) {
     ext["signing.keyId"] = System.getenv('MAVEN_CENTRAL_SIGNING_KEY_ID')
 }
 
+group = "net.pixiv.charcoal"
+
 nexusPublishing {
     repositories {
         sonatype {
-            stagingProfileId = sonatypeStagingProfileId
             username = ossrhUsername
             password = ossrhPassword
 


### PR DESCRIPTION
## 解決したいこと
- ライブラリ公開方法を移行する必要があり、その内容に対応できるよう設定を変更しました。  
  - https://central.sonatype.org/pages/ossrh-eol/

## やったこと
- Maven Central Repository 経由でのアップロード時に stagingProfileId の指定が不要となったため削除
- Staging Repository 生成時に groupId が設定されてない状態となっていたため、必要と思われる箇所に `group` の設定を追加。
  - 各モジュールにも group 設定が残っているが、それらを消すとエラーとなってしまうため残している。もっと効率のより設定方法があるかもしれないが、それはまた別途調査・検討するようにしたい。

## やらないこと
- 

## スクリーンショット
UIに変更が生じた場合はスクショを貼ってください

Before | After
---|---

## 動作確認環境
- 
